### PR TITLE
Improve security and performance headers 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ baseurl: ""
 url: "https://revive.today"
 permalink: /blog/:title
 
-include: ['_redirects']
+include: ['_redirects', '_headers']
 exclude: ['.github', 'README.md', 'LICENSE', 'docker-compose.yml', 'Gemfile.lock', 'Gemfile']
 
 remote_theme: ReviveToday/Modoki-Lite

--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
-  Access-Control-Allow-Origin: *
-  Content-Security-Policy: default-src 'self';
+	Access-Control-Allow-Origin: *
+	Content-Security-Policy: "default-src 'self' style-src 'self' 'unsafe-inline';
 	X-Frame-Options: DENY
 	Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 	

--- a/_headers
+++ b/_headers
@@ -1,0 +1,6 @@
+/*
+  Access-Control-Allow-Origin: *
+  Content-Security-Policy: default-src 'self';
+	X-Frame-Options: DENY
+	Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+	

--- a/_headers
+++ b/_headers
@@ -3,4 +3,3 @@
 	Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline'; img-src 'self' data: *.imgflip.com *.giphy.com
 	X-Frame-Options: DENY
 	Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-	

--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
 	Access-Control-Allow-Origin: *
-	Content-Security-Policy: default-src https: 'unsafe-eval' 'unsafe-inline'; object-src 'none'
+	Content-Security-Policy: default-src https: 'unsafe-eval' 'unsafe-inline'; object-src data: 'unsafe-eval'
 	X-Frame-Options: DENY
 	Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 	

--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
 	Access-Control-Allow-Origin: *
-	Content-Security-Policy: default-src 'self' style-src 'self' 'unsafe-inline' img-src 'self' 'unsafe-inline';
+	Content-Security-Policy: default-src https: 'unsafe-eval' 'unsafe-inline'; object-src 'none'
 	X-Frame-Options: DENY
 	Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 	

--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
 	Access-Control-Allow-Origin: *
-	Content-Security-Policy: default-src https: 'unsafe-eval' 'unsafe-inline'; object-src data: 'unsafe-eval'
+	Content-Security-Policy: default-src https: 'unsafe-inline' 'unsafe-eval'; style-src 'unsafe-inline'; img-src data:
 	X-Frame-Options: DENY
 	Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 	

--- a/_headers
+++ b/_headers
@@ -1,5 +1,6 @@
 /*
 	Access-Control-Allow-Origin: *
+	Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 	Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline'; img-src 'self' data: *.imgflip.com *.giphy.com
 	X-Frame-Options: DENY
-	Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+	X-XSS-Protection: 1; mode=block

--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
 	Access-Control-Allow-Origin: *
-	Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline'; img-src 'self' data:
+	Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline'; img-src 'self' data: *.imgflip.com *.giphy.com
 	X-Frame-Options: DENY
 	Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 	

--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
 	Access-Control-Allow-Origin: *
-	Content-Security-Policy: default-src 'self' style-src 'self' 'unsafe-inline';
+	Content-Security-Policy: default-src 'self' style-src 'self' 'unsafe-inline' img-src 'self' 'unsafe-inline';
 	X-Frame-Options: DENY
 	Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 	

--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
 	Access-Control-Allow-Origin: *
-	Content-Security-Policy: "default-src 'self' style-src 'self' 'unsafe-inline';
+	Content-Security-Policy: default-src 'self' style-src 'self' 'unsafe-inline';
 	X-Frame-Options: DENY
 	Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 	

--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
 	Access-Control-Allow-Origin: *
-	Content-Security-Policy: default-src https: 'unsafe-inline' 'unsafe-eval'; style-src 'unsafe-inline'; img-src data:
+	Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline'; img-src 'self' data:
 	X-Frame-Options: DENY
 	Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 	


### PR DESCRIPTION
RT currently uses the default permission set and default options for Cloudflare Pages. This should improve the security rating and add RT to the preload list.