### PR TITLE
Remove Email Address from Website

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Issue submissions of the following nature are appreciated (ensure they're tagged
 - Fixes and amendments to articles.
 - Website bug reports.
 
-Queries outside of these are better off [emailed to the website owner][rte].
+Queries outside of these are better off [raised on the ReviveToday Discord][rte].
 
 ### Pull Requests
 
@@ -31,5 +31,5 @@ Articles are to be written in [an active tone](https://monzo.com/tone-of-voice/)
 There is ongoing work to provide contribution attribution via a JavaScript widget at the footer of articles. This has yet to be completed.
 
 [rt]:  https://revive.today
-[rte]: mailto:admin@revive.today
+[rte]: https://revive.today/discord
 [l]:   http://creativecommons.org/licenses/by-nc-sa/4.0/

--- a/_config.yml
+++ b/_config.yml
@@ -86,6 +86,8 @@ bootstrap:
     menu:
     - title: Discord
       link: https://revive.today/discord
+    - title: Contact Us
+      link: https://revive.today/contact
   - title: Blog
     page: blog/index.html
 

--- a/_redirects
+++ b/_redirects
@@ -1,5 +1,6 @@
 /roadmap https://github.com/orgs/ReviveToday/projects/3 301
 /discord https://discord.gg/3d3Hz8FJvK 301
+/contact https://forms.gle/gAkowtZmDdU5sL4T9
 /xpapk https://docs.google.com/spreadsheets/d/1_3FNsTmxbK9tTgA_00solkN69TETRKL7GbYcspdp0Yk 301
 /psvita/wtb /psvita/what-to-buy 301
 /ps2/backup /ps2/storage 301

--- a/dmca-takedown.md
+++ b/dmca-takedown.md
@@ -11,7 +11,7 @@ Due to the nature of the content of this site, we understand that the tools and 
 
 Please understand that this website is not operated as part of a business or organisation. This website is run by an individual, and as such instantaneous responses is not a service we can provide. Please be understanding of this when filing a request, we will endeavor to respond as soon as we can possibly verify and react to the request. Requests should be dealt with swiftly, but can take a long time to be processed due to the single-manned nature.
 
-Should you wish to file a Digital Millennium Copyright Act (DMCA) takedown request, please email [admin@revive.today](mailto:admin@revive.today) with the subject starting ‘\[DMCA\] …’ detailing your request. We will need you to provide the following details:
+Should you wish to file a Digital Millennium Copyright Act (DMCA) takedown request, please [visit the Contact Us form](https://revive.today/contact) and select 'DMCA', and detail your request. We will need you to provide the following details:
 
 *   The company or organisation you belong to, or are representing.
 *   The Copyright law(s) of which have been breached.

--- a/ps2/memory-cards.md
+++ b/ps2/memory-cards.md
@@ -9,7 +9,7 @@ Only after spending time on the homebrew communities did I find what the secret 
 
 ## Compressed Memory
 
-This is always a speculated topic on the matter (please [let me know](mailto:admin@revive.today) otherwise). Some cards use a technology called compression to achieve more storage on similar hardware. Compressing data is (in the case of a zip file) when parts of data which is similar to other parts in a container are merged, Simlarly some of the cards will try and compress the savegames so that more can fit on the card. While this isn’t an inherently bad idea, this will cause the system to slow down noticeably, and the higher the storage amount of the worse performance will be. Most games will take this on the chin (Sims 2 is slow on an official 8mb, with a high capacity be prepared to wait a long time), but means the ‘do not remove the card of turn off the console’ space of time is extended for a long time.
+This is always a speculated topic on the matter (please [let me know](https://revive.today/contact) otherwise). Some cards use a technology called compression to achieve more storage on similar hardware. Compressing data is (in the case of a zip file) when parts of data which is similar to other parts in a container are merged, Simlarly some of the cards will try and compress the savegames so that more can fit on the card. While this isn’t an inherently bad idea, this will cause the system to slow down noticeably, and the higher the storage amount of the worse performance will be. Most games will take this on the chin (Sims 2 is slow on an official 8mb, with a high capacity be prepared to wait a long time), but means the ‘do not remove the card of turn off the console’ space of time is extended for a long time.
 
 ## Filesystem Corruption
 

--- a/psp/firmware.md
+++ b/psp/firmware.md
@@ -54,4 +54,4 @@ If in doubt, go for 6.60. If you’re on 6.61, you can stay here and still enjoy
     </div>
 </div>
 
-If you have any firmware versions not listed above, [please send a zipped copy of the EBOOT to us](mailto:admin@revive.today).
+If you have any firmware versions not listed above, [discuss this with us on the ReviveToday Discord](https://revive.today/discord).

--- a/psvita/apps.md
+++ b/psvita/apps.md
@@ -122,7 +122,7 @@ Yet to install CFW on your PS Vita? Vita Hacks Guide has the best installer guid
 	</div>
 </div>
 
-❓ _Missing anything? [Let us know](mailto:admin@revive.today)._
+❓ _Missing anything? [Let us know](https://revive.today/contact)._
 
 ## Installing Vita Applications
 


### PR DESCRIPTION
The website has gained a small level of popularity, and as a result the once useful email inbox has now become littered with marketing and abusive spam. As a result, this mailbox is being sunset in favour of two major forms of communicaion:

* Discord (https://revive.today/discord).
* Google Form (https://forms.gle/gAkowtZmDdU5sL4T9).

This PR replaces all email address references with either of these, with text adjustments where appropriate.

The old email address (admin@revive.today) will eventually be replaced with an auto-responder, with a new private email address given for administrative purposes.